### PR TITLE
feat: add structured validation results with first-error and all-errors functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ import * as assert from "node:assert";
 import {
   typeChecker,
   ensure,
+  validate,
+  validateAll,
+  ValidationIssueCode,
   isString,
   isPositiveSafeInteger,
   isArrayOf,
@@ -81,6 +84,28 @@ const response = await fetch("https://jsonplaceholder.typicode.com/users/1");
 const member = ensure(await response.json(), isUser);
 console.info(`member.id: ${member.id}`);
 console.info(`member.name: ${member.name}`);
+
+// validate returns the first machine-readable issue without throwing.
+const validation = validate({ id: "1", name: "a" }, isUser);
+assert.deepEqual(validation, {
+  ok: false,
+  issue: {
+    path: ["id"],
+    code: ValidationIssueCode.GuardFailed,
+    expected: "TypeChecker<isPositiveSafeInteger>",
+    actualType: "String",
+  },
+});
+
+// validateAll collects every issue discoverable in structural checkers.
+const allValidation = validateAll({ id: "1", name: 1 }, isUser);
+assert.equal(allValidation.ok, false);
+if (!allValidation.ok) {
+  assert.deepEqual(
+    allValidation.issues.map((issue) => issue.path),
+    [["id"], ["name"]],
+  );
+}
 
 // isArrayOf returns TypeChecker<Array<T>>.
 const isUserArray = isArrayOf(isUser);

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -40,3 +40,5 @@ export * from "./parseIpv4Address.ts";
 export * from "./parseIpv6Address.ts";
 export * from "./typeChecker.ts";
 export * from "./types.ts";
+export * from "./validate.ts";
+export * from "./validationIssue.ts";

--- a/src/typeChecker.test.ts
+++ b/src/typeChecker.test.ts
@@ -62,6 +62,36 @@ test("Should detect circular references.", () => {
 	assert.throws(() => isT(obj), /^Error: CircularReference:/);
 });
 
+test("Should test type guards and object definitions.", () => {
+	const isText = typeChecker(
+		(input: unknown): input is string => typeof input === "string",
+		"Text",
+	);
+	assert.equal(isText.test("value"), null);
+
+	const isNamedObject = typeChecker({ name: isText }, "NamedObject");
+	assert.equal(isNamedObject.test({ name: "value" }), null);
+	const rootError = isNamedObject.test(null);
+	assert.ok(rootError instanceof Error);
+	assert.match(rootError.message, /^TypeCheckError: The value /);
+	const propertyError = isNamedObject.test({ name: 1 });
+	assert.ok(propertyError instanceof Error);
+	assert.match(propertyError.message, /^TypeCheckError: \.name /);
+});
+
+test("Should expose cache and unnamed type configuration.", () => {
+	const originalCount = typeCheckerConfig.getNoNameTypeCount();
+	typeCheckerConfig.resetNoNameTypeCount(40);
+	assert.equal(typeCheckerConfig.getNoNameTypeCount(), 40);
+
+	const definition = { value: /value/ };
+	const first = typeChecker(definition, "CachedObject");
+	assert.equal(typeChecker(definition), first);
+	typeCheckerConfig.clearCache();
+	assert.notEqual(typeChecker(definition, "FreshObject"), first);
+	typeCheckerConfig.resetNoNameTypeCount(originalCount);
+});
+
 test("Should serialize definitions (type guard)", () => {
 	typeCheckerConfig.resetNoNameTypeCount();
 	const isT1 = typeChecker(function isFoo() {

--- a/src/typeChecker.ts
+++ b/src/typeChecker.ts
@@ -4,7 +4,15 @@ import type {
 	TypeChecker,
 	TypeDefinition,
 	TypeGuard,
+	ValidationIssue,
 } from "./types.ts";
+import {
+	type Diagnoser,
+	getDiagnoser,
+	setDiagnoser,
+	type ValidationIssueReporter,
+} from "./validation.private.ts";
+import { ValidationIssueCode } from "./validationIssue.ts";
 
 const keys = Object.keys as <T>(o: T) => Array<keyof T>;
 const values = Object.values as <T>(o: T) => Array<T[keyof T]>;
@@ -33,6 +41,13 @@ const getIndent = (depth: number) => "  ".repeat(depth);
 interface FactoryProps<T> {
 	typeGuard: TypeGuard<T>;
 	serialize(depth: number, done: Map<object, string>): Generator<string>;
+	diagnose?: (
+		checker: TypeChecker<T>,
+		input: unknown,
+		path: ReadonlyArray<string | number>,
+		report: ValidationIssueReporter,
+		context: Parameters<Diagnoser>[3],
+	) => boolean;
 	test?(
 		this: TypeChecker<T>,
 		input: unknown,
@@ -49,6 +64,34 @@ const getCache = <T>(context: object) => {
 		cacheStore.set(context, map);
 	}
 	return map as WeakMap<object, { value: T }>;
+};
+
+const createIssue = <T>(
+	checker: TypeChecker<T>,
+	input: unknown,
+	path: ReadonlyArray<string | number>,
+	code: ValidationIssueCode,
+): ValidationIssue => ({
+	path,
+	code,
+	expected: checker.toString(),
+	actualType: getType(input),
+});
+
+const diagnoseCircularReference = <T>(
+	checker: TypeChecker<T>,
+	input: WeakKey,
+	path: ReadonlyArray<string | number>,
+	report: ValidationIssueReporter,
+	context: Parameters<Diagnoser>[3],
+): boolean | null => {
+	if (context.objects.has(input)) {
+		return report(
+			createIssue(checker, input, path, ValidationIssueCode.CircularReference),
+		);
+	}
+	context.objects.add(input);
+	return null;
 };
 
 /**
@@ -85,7 +128,7 @@ const factory =
 		if (cached) {
 			return cached.value;
 		}
-		const { typeGuard, serialize, test } = props(arg, typeName);
+		const { typeGuard, serialize, diagnose, test } = props(arg, typeName);
 		cached = checkerCache.get(typeGuard);
 		if (cached) {
 			return cached.value;
@@ -112,6 +155,14 @@ const factory =
 			cache.set(arg, { value: checker });
 		}
 		checkerCache.set(typeGuard, { value: checker });
+		setDiagnoser(checker, (input, path, report, context) =>
+			diagnose
+				? diagnose(checker, input, path, report, context)
+				: checker(input) ||
+					report(
+						createIssue(checker, input, path, ValidationIssueCode.GuardFailed),
+					),
+		);
 		return checker;
 	};
 
@@ -132,6 +183,11 @@ export const isOptionalOf: <const T>(
 			*serialize(depth, done) {
 				yield* isT.serialize(depth, done);
 				yield " | undefined";
+			},
+			diagnose(_checker, input, path, report, context) {
+				return (
+					is$Undefined(input) || getDiagnoser(isT)(input, path, report, context)
+				);
 			},
 		};
 	},
@@ -156,6 +212,33 @@ export const isArrayOf: <const T>(
 				yield "Array<";
 				yield* isT.serialize(depth, done);
 				yield ">";
+			},
+			diagnose(checker, input, path, report, context) {
+				if (!Array.isArray(input)) {
+					return report(
+						createIssue(checker, input, path, ValidationIssueCode.TypeMismatch),
+					);
+				}
+				const circular = diagnoseCircularReference(
+					checker,
+					input,
+					path,
+					report,
+					context,
+				);
+				if (circular !== null) {
+					return circular;
+				}
+				try {
+					for (const [index, item] of input.entries()) {
+						if (!getDiagnoser(isT)(item, path.concat(index), report, context)) {
+							return false;
+						}
+					}
+					return true;
+				} finally {
+					context.objects.delete(input);
+				}
 			},
 		};
 	},
@@ -189,6 +272,41 @@ export const isDictionaryOf: <const T>(
 				yield "Record<string, ";
 				yield* isT.serialize(depth, done);
 				yield ">";
+			},
+			diagnose(checker, input, path, report, context) {
+				if (!is$Object(input)) {
+					return report(
+						createIssue(checker, input, path, ValidationIssueCode.TypeMismatch),
+					);
+				}
+				const circular = diagnoseCircularReference(
+					checker,
+					input,
+					path,
+					report,
+					context,
+				);
+				if (circular !== null) {
+					return circular;
+				}
+				try {
+					for (const key of keys(input)) {
+						if (
+							typeof key !== "symbol" &&
+							!getDiagnoser(isT)(
+								input[key],
+								path.concat(String(key)),
+								report,
+								context,
+							)
+						) {
+							return false;
+						}
+					}
+					return true;
+				} finally {
+					context.objects.delete(input);
+				}
 			},
 		};
 	},
@@ -236,6 +354,14 @@ export const typeChecker: <const T>(
 			*serialize() {
 				yield d;
 			},
+			diagnose(checker, input, path, report) {
+				return (
+					getType(input) === d ||
+					report(
+						createIssue(checker, input, path, ValidationIssueCode.TypeMismatch),
+					)
+				);
+			},
 		};
 	}
 	if (is$RegExp(d)) {
@@ -243,6 +369,19 @@ export const typeChecker: <const T>(
 			typeGuard: { [k]: (v: unknown): v is T => is$String(v) && d.test(v) }[k],
 			*serialize() {
 				yield `${d}`;
+			},
+			diagnose(checker, input, path, report) {
+				return (
+					(is$String(input) && d.test(input)) ||
+					report(
+						createIssue(
+							checker,
+							input,
+							path,
+							ValidationIssueCode.PatternMismatch,
+						),
+					)
+				);
 			},
 		};
 	}
@@ -258,6 +397,19 @@ export const typeChecker: <const T>(
 					yield JSON.stringify(item);
 				}
 			},
+			diagnose(checker, input, path, report) {
+				return (
+					d.has(input as T) ||
+					report(
+						createIssue(
+							checker,
+							input,
+							path,
+							ValidationIssueCode.ValueMismatch,
+						),
+					)
+				);
+			},
 		};
 	}
 	if (is$Function(d)) {
@@ -265,6 +417,14 @@ export const typeChecker: <const T>(
 			typeGuard: d,
 			*serialize() {
 				yield `${d.name || k}`;
+			},
+			diagnose(checker, input, path, report) {
+				return (
+					d(input) ||
+					report(
+						createIssue(checker, input, path, ValidationIssueCode.GuardFailed),
+					)
+				);
 			},
 		};
 	}
@@ -319,6 +479,41 @@ export const typeChecker: <const T>(
 				yield ",\n";
 			}
 			yield `${getIndent(depth)}}`;
+		},
+		diagnose(checker, input, path, report, context) {
+			if (!is$Object(input)) {
+				return report(
+					createIssue(checker, input, path, ValidationIssueCode.TypeMismatch),
+				);
+			}
+			const circular = diagnoseCircularReference(
+				checker,
+				input,
+				path,
+				report,
+				context,
+			);
+			if (circular !== null) {
+				return circular;
+			}
+			try {
+				for (const [key, property] of properties()) {
+					if (
+						typeof key !== "symbol" &&
+						!getDiagnoser(property)(
+							input[key],
+							path.concat(String(key)),
+							report,
+							context,
+						)
+					) {
+						return false;
+					}
+				}
+				return true;
+			} finally {
+				context.objects.delete(input);
+			}
 		},
 		test(input: unknown, route: Array<string | number | symbol> = []) {
 			if (!is$Object(input)) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { ValidationIssueCode } from "./validationIssue.ts";
+
 /**
  * A generic type to create a nominal type.
  * @example
@@ -81,3 +83,28 @@ export type TypeChecker<T> = TypeGuard<T> & {
 	serialize(depth: number, done: Map<object, string>): Generator<string>;
 	toString(): string;
 };
+
+/** A machine-readable validation issue. */
+export interface ValidationIssue {
+	/** Location of the issue within the input. */
+	readonly path: ReadonlyArray<string | number>;
+	/** Stable machine-readable built-in issue identifier. */
+	readonly code: ValidationIssueCode;
+	/** Description of the expected value, when available. */
+	readonly expected?: string;
+	/** Runtime type name returned by `getType()`, when available. */
+	readonly actualType?: string;
+}
+
+/** The result of first-issue validation. */
+export type ValidationResult<T> =
+	| { readonly ok: true; readonly value: T }
+	| { readonly ok: false; readonly issue: ValidationIssue };
+
+/** The result of all-issues validation. */
+export type ValidationAllResult<T> =
+	| { readonly ok: true; readonly value: T }
+	| {
+			readonly ok: false;
+			readonly issues: readonly [ValidationIssue, ...ValidationIssue[]];
+	  };

--- a/src/validate.test.ts
+++ b/src/validate.test.ts
@@ -156,8 +156,8 @@ test("structural mismatch reports the input runtime type", () => {
 	assert.deepEqual(result.issues[0], {
 		path: ["items"],
 		code: ValidationIssueCode.TypeMismatch,
-		expected:
-			"TypeChecker<Array<T1 {\n  label: isstring,\n  active: isboolean,\n}>>",
+		// Unnamed type numbers depend on the test runner's module load order.
+		expected: definition.items.toString(),
 		actualType: "Null",
 	});
 });

--- a/src/validate.test.ts
+++ b/src/validate.test.ts
@@ -1,0 +1,163 @@
+import * as assert from "node:assert";
+import { test } from "node:test";
+import { isBoolean } from "./is/Boolean.ts";
+import { isString } from "./is/String.ts";
+import { isArrayOf } from "./typeChecker.ts";
+import type { ValidationIssue } from "./types.ts";
+import { validate, validateAll } from "./validate.ts";
+import {
+	ValidationIssueCode,
+	type ValidationIssueCode as ValidationIssueCodeType,
+} from "./validationIssue.ts";
+
+const definition = {
+	name: isString,
+	items: isArrayOf({
+		label: isString,
+		active: isBoolean,
+	}),
+};
+
+test("validate returns the first nested issue", () => {
+	const result = validate(
+		{
+			name: 1,
+			items: [
+				{ label: 2, active: "yes" },
+				{ label: 3, active: false },
+			],
+		},
+		definition,
+	);
+
+	assert.deepEqual(result, {
+		ok: false,
+		issue: {
+			path: ["name"],
+			code: ValidationIssueCode.GuardFailed,
+			expected: "TypeChecker<isstring>",
+			actualType: "Number",
+		},
+	});
+	assert.equal("issues" in result, false);
+});
+
+test("validate stops after the first issue", () => {
+	let calls = 0;
+	const isRejected = (_input: unknown): _input is never => {
+		calls++;
+		return false;
+	};
+	const isRejectedArray = isArrayOf(isRejected);
+
+	const first = validate([1, 2, 3], isRejectedArray);
+	assert.equal(first.ok, false);
+	assert.equal(calls, 1);
+
+	calls = 0;
+	const all = validateAll([1, 2, 3], isRejectedArray);
+	assert.equal(all.ok, false);
+	assert.equal(calls, 3);
+	if (!all.ok) {
+		assert.equal(all.issues.length, 3);
+	}
+});
+
+test("validateAll returns every nested object and array issue", () => {
+	const result = validateAll(
+		{
+			name: 1,
+			items: [
+				{ label: 2, active: "yes" },
+				{ label: 3, active: false },
+			],
+		},
+		definition,
+	);
+
+	assert.equal(result.ok, false);
+	if (result.ok) {
+		return;
+	}
+	assert.deepEqual(
+		result.issues.map(({ path, code, actualType }) => ({
+			path,
+			code,
+			actualType,
+		})),
+		[
+			{
+				path: ["name"],
+				code: ValidationIssueCode.GuardFailed,
+				actualType: "Number",
+			},
+			{
+				path: ["items", 0, "label"],
+				code: ValidationIssueCode.GuardFailed,
+				actualType: "Number",
+			},
+			{
+				path: ["items", 0, "active"],
+				code: ValidationIssueCode.GuardFailed,
+				actualType: "String",
+			},
+			{
+				path: ["items", 1, "label"],
+				code: ValidationIssueCode.GuardFailed,
+				actualType: "Number",
+			},
+		],
+	);
+	const firstIssue: ValidationIssue = result.issues[0];
+	const firstCode: ValidationIssueCodeType = firstIssue.code;
+	assert.deepEqual(firstIssue.path, ["name"]);
+	assert.equal(firstCode, ValidationIssueCode.GuardFailed);
+});
+
+test("successful validation preserves object identity", () => {
+	const input = {
+		name: "example",
+		items: [{ label: "item", active: true }],
+	};
+	const first = validate(input, definition);
+	const all = validateAll(input, definition);
+
+	assert.equal(first.ok, true);
+	assert.equal(all.ok, true);
+	if (first.ok && all.ok) {
+		assert.equal(first.value, input);
+		assert.equal(all.value, input);
+		const name: string = first.value.name;
+		assert.equal(name, "example");
+	}
+});
+
+test("a plain guard contributes one generic issue", () => {
+	const result = validateAll(1, isString);
+	assert.deepEqual(result, {
+		ok: false,
+		issues: [
+			{
+				path: [],
+				code: ValidationIssueCode.GuardFailed,
+				expected: "TypeChecker<isstring>",
+				actualType: "Number",
+			},
+		],
+	});
+});
+
+test("structural mismatch reports the input runtime type", () => {
+	const result = validateAll({ name: "example", items: null }, definition);
+	assert.equal(result.ok, false);
+	if (result.ok) {
+		return;
+	}
+	assert.deepEqual(result.issues[0], {
+		path: ["items"],
+		code: ValidationIssueCode.TypeMismatch,
+		expected:
+			"TypeChecker<Array<T1 {\n  label: isstring,\n  active: isboolean,\n}>>",
+		actualType: "Null",
+	});
+});

--- a/src/validate.test.ts
+++ b/src/validate.test.ts
@@ -2,7 +2,12 @@ import * as assert from "node:assert";
 import { test } from "node:test";
 import { isBoolean } from "./is/Boolean.ts";
 import { isString } from "./is/String.ts";
-import { isArrayOf, isDictionaryOf, typeChecker } from "./typeChecker.ts";
+import {
+	isArrayOf,
+	isDictionaryOf,
+	isOptionalOf,
+	typeChecker,
+} from "./typeChecker.ts";
 import type { ValidationIssue } from "./types.ts";
 import { validate, validateAll } from "./validate.ts";
 import {
@@ -224,6 +229,7 @@ test("built-in definitions report their specific issue codes", () => {
 
 test("dictionary validation reports structural and entry issues", () => {
 	const checker = isDictionaryOf(isString, "StringDictionary");
+	assert.equal(checker(null), false);
 	assert.deepEqual(validate(null, checker), {
 		ok: false,
 		issue: {
@@ -247,5 +253,36 @@ test("dictionary validation reports structural and entry issues", () => {
 	assert.deepEqual(validateAll(input, checker), {
 		ok: false,
 		issues: [expectedIssue],
+	});
+});
+
+test("optional validation accepts undefined and reports invalid values", () => {
+	const checker = isOptionalOf(isString, "OptionalString");
+	assert.equal(checker.toString(), "TypeChecker<isstring | undefined>");
+	assert.deepEqual(validate(undefined, checker), {
+		ok: true,
+		value: undefined,
+	});
+	assert.deepEqual(validate(1, checker), {
+		ok: false,
+		issue: {
+			path: [],
+			code: ValidationIssueCode.GuardFailed,
+			expected: "TypeChecker<isstring>",
+			actualType: "Number",
+		},
+	});
+});
+
+test("root object mismatch reports a structured issue", () => {
+	const checker = typeChecker({ value: isString }, "NamedObject");
+	assert.deepEqual(validate(null, checker), {
+		ok: false,
+		issue: {
+			path: [],
+			code: ValidationIssueCode.TypeMismatch,
+			expected: "TypeChecker<NamedObject {\n  value: isstring,\n}>",
+			actualType: "Null",
+		},
 	});
 });

--- a/src/validate.test.ts
+++ b/src/validate.test.ts
@@ -2,7 +2,7 @@ import * as assert from "node:assert";
 import { test } from "node:test";
 import { isBoolean } from "./is/Boolean.ts";
 import { isString } from "./is/String.ts";
-import { isArrayOf, typeChecker } from "./typeChecker.ts";
+import { isArrayOf, isDictionaryOf, typeChecker } from "./typeChecker.ts";
 import type { ValidationIssue } from "./types.ts";
 import { validate, validateAll } from "./validate.ts";
 import {
@@ -189,5 +189,63 @@ test("structural mismatch reports the input runtime type", () => {
 		// Unnamed type numbers depend on the test runner's module load order.
 		expected: definition.items.toString(),
 		actualType: "Null",
+	});
+});
+
+test("built-in definitions report their specific issue codes", () => {
+	assert.deepEqual(validate(null, "Date"), {
+		ok: false,
+		issue: {
+			path: [],
+			code: ValidationIssueCode.TypeMismatch,
+			expected: "TypeChecker<Date>",
+			actualType: "Null",
+		},
+	});
+	assert.deepEqual(validate("invalid", /^valid$/), {
+		ok: false,
+		issue: {
+			path: [],
+			code: ValidationIssueCode.PatternMismatch,
+			expected: "TypeChecker</^valid$/>",
+			actualType: "String",
+		},
+	});
+	assert.deepEqual(validate("green", new Set(["red", "blue"])), {
+		ok: false,
+		issue: {
+			path: [],
+			code: ValidationIssueCode.ValueMismatch,
+			expected: 'TypeChecker<"red" | "blue">',
+			actualType: "String",
+		},
+	});
+});
+
+test("dictionary validation reports structural and entry issues", () => {
+	const checker = isDictionaryOf(isString, "StringDictionary");
+	assert.deepEqual(validate(null, checker), {
+		ok: false,
+		issue: {
+			path: [],
+			code: ValidationIssueCode.TypeMismatch,
+			expected: "TypeChecker<Record<string, isstring>>",
+			actualType: "Null",
+		},
+	});
+	const input = { valid: "value", invalid: 1 };
+	const expectedIssue = {
+		path: ["invalid"],
+		code: ValidationIssueCode.GuardFailed,
+		expected: "TypeChecker<isstring>",
+		actualType: "Number",
+	};
+	assert.deepEqual(validate(input, checker), {
+		ok: false,
+		issue: expectedIssue,
+	});
+	assert.deepEqual(validateAll(input, checker), {
+		ok: false,
+		issues: [expectedIssue],
 	});
 });

--- a/src/validate.test.ts
+++ b/src/validate.test.ts
@@ -2,7 +2,7 @@ import * as assert from "node:assert";
 import { test } from "node:test";
 import { isBoolean } from "./is/Boolean.ts";
 import { isString } from "./is/String.ts";
-import { isArrayOf } from "./typeChecker.ts";
+import { isArrayOf, typeChecker } from "./typeChecker.ts";
 import type { ValidationIssue } from "./types.ts";
 import { validate, validateAll } from "./validate.ts";
 import {
@@ -112,6 +112,36 @@ test("validateAll returns every nested object and array issue", () => {
 	const firstCode: ValidationIssueCodeType = firstIssue.code;
 	assert.deepEqual(firstIssue.path, ["name"]);
 	assert.equal(firstCode, ValidationIssueCode.GuardFailed);
+});
+
+test("circular references return structured issues", () => {
+	const checker = typeChecker(
+		{
+			value: isString,
+			sub: { value: isString },
+		},
+		"CircularNode",
+	);
+	const input = {
+		value: "root",
+		sub: { value: "child" },
+	};
+	input.sub = input;
+	const expectedIssue = {
+		path: ["sub"],
+		code: ValidationIssueCode.CircularReference,
+		expected: "TypeChecker<CircularNode.sub {\n  value: isstring,\n}>",
+		actualType: "Object",
+	};
+
+	assert.deepEqual(validate(input, checker), {
+		ok: false,
+		issue: expectedIssue,
+	});
+	assert.deepEqual(validateAll(input, checker), {
+		ok: false,
+		issues: [expectedIssue],
+	});
 });
 
 test("successful validation preserves object identity", () => {

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,0 +1,61 @@
+import { typeChecker } from "./typeChecker.ts";
+import type {
+	TypeDefinition,
+	ValidationAllResult,
+	ValidationIssue,
+	ValidationResult,
+} from "./types.ts";
+import { getDiagnoser } from "./validation.private.ts";
+
+/**
+ * Validates an input and returns the first issue found.
+ *
+ * The successful result contains the original input without transforming it.
+ */
+export const validate = <const T>(
+	input: unknown,
+	definition: TypeDefinition<T>,
+): ValidationResult<T> => {
+	const checker = typeChecker(definition);
+	let issue: ValidationIssue | undefined;
+	getDiagnoser(checker)(
+		input,
+		[],
+		(found) => {
+			issue = found;
+			return false;
+		},
+		{ objects: new WeakSet() },
+	);
+	return issue ? { ok: false, issue } : { ok: true, value: input as T };
+};
+
+/**
+ * Validates an input and returns every issue discoverable by library-owned
+ * structural checkers.
+ *
+ * A plain boolean type guard contributes at most one issue. The successful
+ * result contains the original input without transforming it.
+ */
+export const validateAll = <const T>(
+	input: unknown,
+	definition: TypeDefinition<T>,
+): ValidationAllResult<T> => {
+	const checker = typeChecker(definition);
+	const issues: Array<ValidationIssue> = [];
+	getDiagnoser(checker)(
+		input,
+		[],
+		(issue) => {
+			issues.push(issue);
+			return true;
+		},
+		{ objects: new WeakSet() },
+	);
+	return issues.length
+		? {
+				ok: false,
+				issues: issues as [ValidationIssue, ...Array<ValidationIssue>],
+			}
+		: { ok: true, value: input as T };
+};

--- a/src/validation.private.ts
+++ b/src/validation.private.ts
@@ -1,0 +1,31 @@
+import type { TypeChecker, ValidationIssue } from "./types.ts";
+
+export interface ValidationContext {
+	readonly objects: WeakSet<WeakKey>;
+}
+
+export type ValidationIssueReporter = (issue: ValidationIssue) => boolean;
+
+export type Diagnoser = (
+	input: unknown,
+	path: ReadonlyArray<string | number>,
+	report: ValidationIssueReporter,
+	context: ValidationContext,
+) => boolean;
+
+const diagnosers = new WeakMap<object, Diagnoser>();
+
+export const getDiagnoser = <T>(checker: TypeChecker<T>): Diagnoser => {
+	const diagnose = diagnosers.get(checker);
+	if (!diagnose) {
+		throw new Error("TypeChecker diagnoser is not registered");
+	}
+	return diagnose;
+};
+
+export const setDiagnoser = <T>(
+	checker: TypeChecker<T>,
+	diagnose: Diagnoser,
+): void => {
+	diagnosers.set(checker, diagnose);
+};

--- a/src/validationIssue.ts
+++ b/src/validationIssue.ts
@@ -1,0 +1,12 @@
+/** Built-in machine-readable validation issue codes. */
+export const ValidationIssueCode = {
+	CircularReference: "circular_reference",
+	GuardFailed: "guard_failed",
+	PatternMismatch: "pattern_mismatch",
+	TypeMismatch: "type_mismatch",
+	ValueMismatch: "value_mismatch",
+} as const;
+
+/** A built-in machine-readable validation issue code. */
+export type ValidationIssueCode =
+	(typeof ValidationIssueCode)[keyof typeof ValidationIssueCode];


### PR DESCRIPTION
## Summary

- add `validate()` and `validateAll()` with structured machine-readable issues
- export built-in issue codes through `ValidationIssueCode`
- collect nested object and array issues through private checker diagnostics
- preserve the existing boolean guard, `ensure()`, and `TypeChecker.test()` paths

## Tests

- `npm run lint`
- `npm run test:type`
- `npm run test:unit`
- `npm run test:example`

Closes #434
