### PR TITLE
breaking: make object definitions exact by default and add isObjectWith

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ import {
   isPositiveSafeInteger,
   isArrayOf,
   isDictionaryOf,
+  isObjectWith,
   isOptionalOf,
 } from "@nlib/typing";
 
@@ -79,9 +80,14 @@ const isUser = typeChecker({
 assert.equal(isUser({ id: 1, name: "a" }), true);
 assert.equal(isUser({ id: "1", name: "a" }), false);
 
-// You can handle a response with confidence using ensure().
+// API responses commonly contain additional fields, so validate this one as
+// an open shape with isObjectWith().
+const isUserResponse = isObjectWith({
+  id: isPositiveSafeInteger,
+  name: isString,
+});
 const response = await fetch("https://jsonplaceholder.typicode.com/users/1");
-const member = ensure(await response.json(), isUser);
+const member = ensure(await response.json(), isUserResponse);
 console.info(`member.id: ${member.id}`);
 console.info(`member.name: ${member.name}`);
 
@@ -137,6 +143,12 @@ const isItem = typeChecker({
 assert.equal(isItem({ id: 1 }), true);
 assert.equal(isItem({ id: 1, name: "a" }), true);
 assert.equal(isItem({ id: 1, name: 1 }), false);
+
+// Object definitions are exact by default. Unknown fields are rejected.
+assert.equal(isUser({ id: 1, name: "a", admin: true }), false);
+
+// isObjectWith keeps open-shape matching when additional fields are expected.
+assert.equal(isUserResponse({ id: 1, name: "a", admin: true }), true);
 
 // Example: Tree structure
 interface Node {

--- a/example.test.ts
+++ b/example.test.ts
@@ -3,6 +3,7 @@ import {
 	ensure,
 	isArrayOf,
 	isDictionaryOf,
+	isObjectWith,
 	isOptionalOf,
 	isPositiveSafeInteger,
 	isString,
@@ -26,9 +27,14 @@ const isUser = typeChecker({
 assert.equal(isUser({ id: 1, name: "a" }), true);
 assert.equal(isUser({ id: "1", name: "a" }), false);
 
-// You can handle a response with confidence using ensure().
+// API responses commonly contain additional fields, so validate this one as
+// an open shape with isObjectWith().
+const isUserResponse = isObjectWith({
+	id: isPositiveSafeInteger,
+	name: isString,
+});
 const response = await fetch("https://jsonplaceholder.typicode.com/users/1");
-const member = ensure(await response.json(), isUser);
+const member = ensure(await response.json(), isUserResponse);
 console.info(`member.id: ${member.id}`);
 console.info(`member.name: ${member.name}`);
 

--- a/src/constTypeParams.test.ts
+++ b/src/constTypeParams.test.ts
@@ -9,13 +9,15 @@
  */
 import * as assert from "node:assert";
 import { test } from "node:test";
+import { isString } from "./is/String.ts";
 import {
 	isArrayOf,
 	isDictionaryOf,
+	isObjectWith,
 	isOptionalOf,
 	typeChecker,
 } from "./typeChecker.ts";
-import type { TypeChecker } from "./types.ts";
+import type { ObjectTypeDefinition, TypeChecker } from "./types.ts";
 
 // ---------------------------------------------------------------------------
 // Compile-time assertions
@@ -41,12 +43,26 @@ const _isArrayAB: TypeChecker<Array<"a" | "b">> = isArrayOf(
 const _isDictAB: TypeChecker<Record<string, "a" | "b">> = isDictionaryOf(
 	new Set(["a", "b"]),
 );
+/** Verify isObjectWith infers object properties and their literal unions. */
+const _isObjectWithAB: TypeChecker<{ kind: "a" | "b" }> = isObjectWith({
+	kind: new Set(["a", "b"]),
+});
+/** Verify the public object-definition type composes field definitions. */
+const _objectDefinition: ObjectTypeDefinition<{
+	kind: "a" | "b";
+	label: string;
+}> = {
+	kind: new Set(["a", "b"]),
+	label: isString,
+};
 
 // Suppress "declared but never used" warnings.
 void _isAB;
 void _isOptionalAB;
 void _isArrayAB;
 void _isDictAB;
+void _isObjectWithAB;
+void _objectDefinition;
 
 // ---------------------------------------------------------------------------
 // Runtime tests
@@ -81,6 +97,13 @@ test("isDictionaryOf(Set) accepts records of members", () => {
 	assert.equal(isColorDictionary({ a: "red", b: "green" }), true);
 	assert.equal(isColorDictionary({}), true);
 	assert.equal(isColorDictionary({ a: "yellow" }), false);
+});
+
+test("isObjectWith infers and checks literal object properties", () => {
+	const isTagged = isObjectWith({ kind: new Set(["a", "b"]) });
+	assert.equal(isTagged({ kind: "a" }), true);
+	assert.equal(isTagged({ kind: "b", extra: true }), true);
+	assert.equal(isTagged({ kind: "c" }), false);
 });
 
 test("typeChecker(Set) works with numeric literals", () => {

--- a/src/typeChecker.test.ts
+++ b/src/typeChecker.test.ts
@@ -185,6 +185,7 @@ test("Should expose cache and unnamed type configuration.", () => {
 	assert.equal(typeChecker(definition), first);
 	typeCheckerConfig.clearCache();
 	assert.notEqual(typeChecker(definition, "FreshObject"), first);
+	assert.equal(typeChecker(first), first);
 	typeCheckerConfig.resetNoNameTypeCount(originalCount);
 });
 

--- a/src/typeChecker.test.ts
+++ b/src/typeChecker.test.ts
@@ -1,6 +1,13 @@
 import * as assert from "node:assert";
 import { test } from "node:test";
-import { isArrayOf, typeChecker, typeCheckerConfig } from "./typeChecker.ts";
+import { isString } from "./is/String.ts";
+import {
+	isArrayOf,
+	isObjectWith,
+	isOptionalOf,
+	typeChecker,
+	typeCheckerConfig,
+} from "./typeChecker.ts";
 import type { Nominal, TypeChecker } from "./types.ts";
 
 test("Should able to define tree structures", () => {
@@ -77,6 +84,95 @@ test("Should test type guards and object definitions.", () => {
 	const propertyError = isNamedObject.test({ name: 1 });
 	assert.ok(propertyError instanceof Error);
 	assert.match(propertyError.message, /^TypeCheckError: \.name /);
+});
+
+test("exact object definitions reject unknown and missing own properties", () => {
+	const isPerson = typeChecker({ name: isString }, "Person");
+
+	assert.equal(isPerson({ name: "Ada" }), true);
+	assert.equal(isPerson({ name: "Ada", role: "admin" }), false);
+	assert.equal(isPerson({}), false);
+	assert.equal(isPerson({ toString: "Ada" }), false);
+
+	const isObjectWithOwnToString = typeChecker({ toString: isString });
+	assert.equal(isObjectWithOwnToString({}), false);
+	assert.equal(isObjectWithOwnToString({ toString: "value" }), true);
+});
+
+test("exact object definitions accept optional, symbol, and hidden properties", () => {
+	const symbol = Symbol("metadata");
+	const isPerson = typeChecker({
+		name: isString,
+		nickname: isOptionalOf(isString),
+	});
+	const input: {
+		name: string;
+		nickname?: string;
+		[symbol]: number;
+		hidden?: number;
+	} = { name: "Ada", [symbol]: 1 };
+	Object.defineProperty(input, "hidden", { enumerable: false, value: 2 });
+
+	assert.equal(isPerson(input), true);
+	input.nickname = undefined;
+	assert.equal(isPerson(input), true);
+	input.nickname = "A";
+	assert.equal(isPerson(input), true);
+});
+
+test("exact object definitions accept Object.prototype and null prototypes", () => {
+	const checker = typeChecker({ name: isString });
+	const nullPrototype = Object.assign(Object.create(null), { name: "Ada" });
+
+	assert.equal(checker({ name: "Ada" }), true);
+	assert.equal(checker(nullPrototype), true);
+});
+
+test("exact object definitions reject arrays, functions, and class instances", () => {
+	class Person {
+		name = "Ada";
+	}
+	const isNamed = typeChecker({ name: isString });
+	const array = Object.assign([], { name: "Ada" });
+	const fn = Object.assign(() => undefined, { nameValue: "Ada" });
+
+	assert.equal(isNamed(array), false);
+	assert.equal(typeChecker({ nameValue: isString })(fn), false);
+	assert.equal(isNamed(new Person()), false);
+});
+
+test("nested definitions are exact unless isObjectWith is explicit", () => {
+	const exact = typeChecker({ profile: { name: isString } });
+	const openNested = typeChecker({
+		profile: isObjectWith({ name: isString }),
+	});
+	const input = { profile: { name: "Ada", role: "admin" } };
+
+	assert.equal(exact(input), false);
+	assert.equal(openNested(input), true);
+	assert.equal(openNested({ ...input, rootExtra: true }), false);
+});
+
+test("isObjectWith preserves open shape matching", () => {
+	class Person {
+		name = "Ada";
+	}
+	const definition = { name: isString };
+	const checker = isObjectWith(definition, "NamedShape");
+	const inherited = Object.create({ name: "Ada" });
+	const array = Object.assign([], { name: "Ada" });
+	const namedFunction = function Ada() {};
+
+	assert.equal(checker({ name: "Ada", role: "admin" }), true);
+	assert.equal(checker(inherited), true);
+	assert.equal(checker(array), true);
+	assert.equal(checker(namedFunction), true);
+	assert.equal(checker(new Person()), true);
+	assert.equal(checker({ role: "admin" }), false);
+	assert.equal(checker(null), false);
+	assert.equal(checker, isObjectWith(definition));
+	assert.notEqual(checker, typeChecker(definition));
+	assert.equal(`${checker}`, "TypeChecker<NamedShape {\n  name: isstring,\n}>");
 });
 
 test("Should expose cache and unnamed type configuration.", () => {

--- a/src/typeChecker.ts
+++ b/src/typeChecker.ts
@@ -1,6 +1,7 @@
 import { getType } from "./getType.ts";
 import type {
 	Callable,
+	ObjectTypeDefinition,
 	TypeChecker,
 	TypeDefinition,
 	TypeGuard,
@@ -27,6 +28,13 @@ const is$Set = (v: unknown): v is Set<unknown> => getType(v) === "Set";
 const is$Function = (v: unknown): v is Callable => typeof v === "function";
 const is$Object = (v: unknown): v is Record<PropertyKey, unknown> =>
 	is$Function(v) || (typeof v === "object" && v !== null);
+const is$PlainObject = (v: unknown): v is Record<PropertyKey, unknown> => {
+	if (typeof v !== "object" || v === null) {
+		return false;
+	}
+	const prototype = Object.getPrototypeOf(v);
+	return prototype === Object.prototype || prototype === null;
+};
 const lazy = <T>(getter: () => T): (() => T) => {
 	let cached: { value: T } | null = null;
 	return () => {
@@ -428,6 +436,29 @@ export const typeChecker: <const T>(
 			},
 		};
 	}
+	return objectFactoryProps(d, typeName, true);
+});
+
+/**
+ * Creates an open-shape type checker from an object definition.
+ *
+ * Declared properties are validated, while additional properties are allowed.
+ * Unlike an object definition passed directly to `typeChecker()`, this checker
+ * retains shape-based matching for functions, arrays, and class instances.
+ */
+export const isObjectWith: <const T extends object>(
+	definition: ObjectTypeDefinition<T>,
+	typeName?: string,
+) => TypeChecker<T> = factory(
+	<T extends object>(d: ObjectTypeDefinition<T>, typeName: string) =>
+		objectFactoryProps(d, typeName, false),
+);
+
+const objectFactoryProps = <T>(
+	d: { [K in keyof T]: TypeDefinition<T[K]> },
+	typeName: string,
+	exact: boolean,
+): FactoryProps<T> => {
 	type PropertyTuple<K extends keyof T = keyof T> = readonly [
 		K,
 		TypeChecker<T[K]>,
@@ -439,6 +470,19 @@ export const typeChecker: <const T>(
 	const properties = lazy(
 		(): Array<PropertyTuple> => keys(d).map((k) => toPropertyTuple(k)),
 	);
+	const propertyKeys = lazy(
+		() => new Set<PropertyKey>(properties().map(([key]) => key)),
+	);
+	const acceptsObject = (
+		input: unknown,
+	): input is Record<PropertyKey, unknown> =>
+		exact ? is$PlainObject(input) : is$Object(input);
+	const hasUnknownKey = (input: Record<PropertyKey, unknown>): boolean =>
+		keys(input).some((key) => !propertyKeys().has(key));
+	const getProperty = (
+		input: Record<PropertyKey, unknown>,
+		key: keyof T,
+	): unknown => (exact && !Object.hasOwn(input, key) ? undefined : input[key]);
 	type TypeGuardWithRefs<U> = (
 		input: unknown,
 		refs?: WeakMap<WeakKey, string>,
@@ -452,14 +496,19 @@ export const typeChecker: <const T>(
 		v: unknown,
 		refs = new WeakMap<WeakKey, string>(),
 	): v is T => {
-		if (!is$Object(v)) {
+		if (!acceptsObject(v)) {
 			return false;
 		}
 		if (refs.has(v)) {
 			throw new Error(`CircularReference: ${refs.get(v)} -> ${typeName}`);
 		}
+		if (exact && hasUnknownKey(v)) {
+			return false;
+		}
 		refs.set(v, typeName);
-		return properties().every(([k, is]) => runGuard(is, v[k], refs));
+		return properties().every(([k, is]) =>
+			runGuard(is, getProperty(v, k), refs),
+		);
 	};
 	return {
 		typeGuard,
@@ -481,7 +530,7 @@ export const typeChecker: <const T>(
 			yield `${getIndent(depth)}}`;
 		},
 		diagnose(checker, input, path, report, context) {
-			if (!is$Object(input)) {
+			if (!acceptsObject(input)) {
 				return report(
 					createIssue(checker, input, path, ValidationIssueCode.TypeMismatch),
 				);
@@ -497,11 +546,20 @@ export const typeChecker: <const T>(
 				return circular;
 			}
 			try {
+				if (
+					exact &&
+					hasUnknownKey(input) &&
+					!report(
+						createIssue(checker, input, path, ValidationIssueCode.TypeMismatch),
+					)
+				) {
+					return false;
+				}
 				for (const [key, property] of properties()) {
 					if (
 						typeof key !== "symbol" &&
 						!getDiagnoser(property)(
-							input[key],
+							getProperty(input, key),
 							path.concat(String(key)),
 							report,
 							context,
@@ -516,11 +574,11 @@ export const typeChecker: <const T>(
 			}
 		},
 		test(input: unknown, route: Array<string | number | symbol> = []) {
-			if (!is$Object(input)) {
+			if (!acceptsObject(input) || (exact && hasUnknownKey(input))) {
 				return new TypeCheckError(this, input);
 			}
 			for (const [k, pd] of properties()) {
-				const error = pd.test(input[k], route.concat(k));
+				const error = pd.test(getProperty(input, k), route.concat(k));
 				if (error) {
 					return error;
 				}
@@ -528,7 +586,7 @@ export const typeChecker: <const T>(
 			return null;
 		},
 	};
-});
+};
 
 class TypeCheckError<T> extends Error {
 	constructor(

--- a/src/typeChecker.ts
+++ b/src/typeChecker.ts
@@ -65,6 +65,9 @@ interface FactoryProps<T> {
 
 let noNameTypeCount = 0;
 let cacheStore = new WeakMap<object, WeakMap<object, { value: unknown }>>();
+// Type guards are decorated in place, so their checker identity must survive
+// clearing the definition caches.
+const checkerStore = new WeakMap<object, { value: unknown }>();
 const getCache = <T>(context: object) => {
 	let map = cacheStore.get(context);
 	if (!map) {
@@ -127,7 +130,10 @@ export const typeCheckerConfig: {
 const factory =
 	<T, A>(props: (arg: A, name: string) => FactoryProps<T>) =>
 	(arg: A, typeName = `T${++noNameTypeCount}`) => {
-		const checkerCache = getCache<TypeChecker<T>>(factory);
+		const checkerCache = checkerStore as WeakMap<
+			object,
+			{ value: TypeChecker<T> }
+		>;
 		const cache = getCache<TypeChecker<T>>(props);
 		let cached: { value: TypeChecker<T> } | undefined;
 		if (is$Object(arg)) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,11 @@ export type TypeGuard<T> = (input: unknown) => input is T;
  */
 export type Guarded<T> = T extends TypeGuard<infer S> ? S : never;
 
+/** An object type definition used by `typeChecker()` and `isObjectWith()`. */
+export type ObjectTypeDefinition<T extends object> = {
+	[K in keyof T]: TypeDefinition<T[K]>;
+};
+
 /**
  * A type of the first argument of `typeChecker()`.
  */

--- a/src/validate.test.ts
+++ b/src/validate.test.ts
@@ -5,6 +5,7 @@ import { isString } from "./is/String.ts";
 import {
 	isArrayOf,
 	isDictionaryOf,
+	isObjectWith,
 	isOptionalOf,
 	typeChecker,
 } from "./typeChecker.ts";
@@ -285,4 +286,49 @@ test("root object mismatch reports a structured issue", () => {
 			actualType: "Null",
 		},
 	});
+});
+
+test("exact and open objects retain their structured validation behavior", () => {
+	const exact = typeChecker({ name: isString }, "ExactPerson");
+	const open = isObjectWith({ name: isString }, "OpenPerson");
+	const input = { name: 1, extra: true };
+
+	assert.deepEqual(validate(input, exact), {
+		ok: false,
+		issue: {
+			path: [],
+			code: ValidationIssueCode.TypeMismatch,
+			expected: "TypeChecker<ExactPerson {\n  name: isstring,\n}>",
+			actualType: "Object",
+		},
+	});
+	const all = validateAll(input, exact);
+	assert.equal(all.ok, false);
+	if (!all.ok) {
+		assert.deepEqual(
+			all.issues.map(({ path, code }) => ({ path, code })),
+			[
+				{ path: [], code: ValidationIssueCode.TypeMismatch },
+				{ path: ["name"], code: ValidationIssueCode.GuardFailed },
+			],
+		);
+	}
+	assert.deepEqual(validate({ name: "Ada", extra: true }, open), {
+		ok: true,
+		value: { name: "Ada", extra: true },
+	});
+});
+
+test("exact object validation preserves its input without sanitizing it", () => {
+	const checker = typeChecker({ name: isString });
+	const input = Object.freeze({ name: "Ada" });
+	const before = Object.getOwnPropertyDescriptors(input);
+	const result = validate(input, checker);
+
+	assert.equal(result.ok, true);
+	if (result.ok) {
+		assert.equal(result.value, input);
+	}
+	assert.deepEqual(Object.getOwnPropertyDescriptors(input), before);
+	assert.equal(Object.isFrozen(input), true);
 });


### PR DESCRIPTION
## Summary

- make direct object definitions exact plain-object checks by default
- add the public isObjectWith() combinator for legacy open-shape validation
- document migration guidance and cover runtime, diagnostics, identity, and inference

## Tests

- npx biome format --write (modified source files)
- npm run lint
- npm run test:type
- focused Node tests
- npm run test:unit
- npx c8 npm run test
- npm run build
- ESM and CommonJS package-entry smoke tests

Closes #435