### PR TITLE
feat: add narrow for composable type-guard refinements with diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,10 @@ import { typeChecker } from 'https://esm.sh/@nlib/typing@3.0.0';
 ```typescript
 import * as assert from "node:assert";
 import {
+  type Nominal,
   typeChecker,
   ensure,
+  narrow,
   validate,
   validateAll,
   ValidationIssueCode,
@@ -79,6 +81,26 @@ const isUser = typeChecker({
 // i.e. TypeChecker<User> is (value: unknown) => value is User
 assert.equal(isUser({ id: 1, name: "a" }), true);
 assert.equal(isUser({ id: "1", name: "a" }), false);
+
+// narrow composes a base TypeGuard with a reusable subtype predicate.
+type EmailAddress = Nominal<string, "EmailAddress">;
+const hasEmailAddressSyntax = (value: string): value is EmailAddress =>
+  /^[^@]+@[^@]+$/.test(value);
+const isContactEmail = narrow(isString, hasEmailAddressSyntax, () => [
+  {
+    code: "invalid_email_address",
+    expected: "an email address containing @",
+  },
+]);
+assert.equal(isContactEmail("ada@example.com"), true);
+assert.deepEqual(validate("invalid", isContactEmail), {
+  ok: false,
+  issue: {
+    path: [],
+    code: "invalid_email_address",
+    expected: "an email address containing @",
+  },
+});
 
 // API responses commonly contain additional fields, so validate this one as
 // an open shape with isObjectWith().

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -36,6 +36,7 @@ export * from "./is/UUID.ts";
 export * from "./is/UUIDLowercase.ts";
 export * from "./is/UUIDUppercase.ts";
 export * from "./is/ValidDate.ts";
+export * from "./narrow.ts";
 export * from "./parseIpv4Address.ts";
 export * from "./parseIpv6Address.ts";
 export * from "./typeChecker.ts";

--- a/src/narrow.test.ts
+++ b/src/narrow.test.ts
@@ -1,0 +1,252 @@
+import * as assert from "node:assert";
+import { test } from "node:test";
+import { ensure } from "./ensure.ts";
+import { isBoolean } from "./is/Boolean.ts";
+import { isString } from "./is/String.ts";
+import { narrow } from "./narrow.ts";
+import { typeChecker } from "./typeChecker.ts";
+import type {
+	Guarded,
+	NarrowingGuard,
+	Nominal,
+	TypeChecker,
+	TypeGuard,
+} from "./types.ts";
+import { validate, validateAll } from "./validate.ts";
+import { ValidationIssueCode } from "./validationIssue.ts";
+
+type EmailAddress = Nominal<string, "EmailAddress">;
+const matchesEmailAddressRules: NarrowingGuard<string, EmailAddress> = (
+	value,
+): value is EmailAddress => /^[^@]+@[^@]+$/.test(value);
+const isEmailAddress = narrow(isString, matchesEmailAddressRules);
+const _emailAddressGuard: TypeGuard<EmailAddress> = isEmailAddress;
+type IsEqual<T, U> =
+	(<V>() => V extends T ? 1 : 2) extends <V>() => V extends U ? 1 : 2
+		? true
+		: false;
+const _emailAddressType: IsEqual<
+	Guarded<typeof isEmailAddress>,
+	EmailAddress
+> = true;
+void _emailAddressGuard;
+void _emailAddressType;
+
+test("narrow preserves subtype inference and leaves the predicate reusable", () => {
+	assert.equal("test" in isEmailAddress, false);
+	const text = "a@example.com";
+	assert.equal(matchesEmailAddressRules(text), true);
+	if (matchesEmailAddressRules(text)) {
+		const email: EmailAddress = text;
+		assert.equal(email, text);
+	}
+
+	const input: unknown = "a@example.com";
+	assert.equal(isEmailAddress(input), true);
+	if (isEmailAddress(input)) {
+		const email: EmailAddress = input;
+		assert.equal(email, input);
+	}
+	assert.equal(isEmailAddress("invalid"), false);
+	assert.equal(isEmailAddress(1), false);
+});
+
+test("the boolean path short-circuits and never executes diagnosis", () => {
+	type NonEmptyString = Nominal<string, "NonEmptyString">;
+	const calls: Array<string> = [];
+	const base = (input: unknown): input is string => {
+		calls.push("base");
+		return typeof input === "string";
+	};
+	const nonEmpty = (value: string): value is NonEmptyString => {
+		calls.push("narrowing");
+		return value.length > 0;
+	};
+	const guard = narrow(base, nonEmpty, () => {
+		calls.push("diagnosis");
+		return [{ code: "empty_string" }];
+	});
+
+	assert.equal(guard(1), false);
+	assert.deepEqual(calls, ["base"]);
+	calls.length = 0;
+	assert.equal(guard(""), false);
+	assert.deepEqual(calls, ["base", "narrowing"]);
+	calls.length = 0;
+	assert.equal(guard("value"), true);
+	assert.deepEqual(calls, ["base", "narrowing"]);
+});
+
+test("structured validation preserves base failures and short-circuits", () => {
+	type NonEmptyString = Nominal<string, "NonEmptyString">;
+	let baseCalls = 0;
+	let narrowingCalls = 0;
+	let diagnosisCalls = 0;
+	const base: TypeChecker<string> = typeChecker(
+		(input: unknown): input is string => {
+			baseCalls++;
+			return typeof input === "string";
+		},
+		"TrackedString",
+	);
+	const guard = narrow(
+		base,
+		(value): value is NonEmptyString => {
+			narrowingCalls++;
+			return value.length > 0;
+		},
+		() => {
+			diagnosisCalls++;
+			return [{ code: "empty_string" }];
+		},
+	);
+
+	assert.deepEqual(validate(1, guard), {
+		ok: false,
+		issue: {
+			path: [],
+			code: ValidationIssueCode.GuardFailed,
+			expected: base.toString(),
+			actualType: "Number",
+		},
+	});
+	assert.equal(baseCalls, 1);
+	assert.equal(narrowingCalls, 0);
+	assert.equal(diagnosisCalls, 0);
+});
+
+test("custom narrowing diagnostics retain paths and support multiple issues", () => {
+	const guard = narrow(isString, matchesEmailAddressRules, function* () {
+		yield {
+			code: "email_missing_at_sign",
+			expected: "an email address containing @",
+		};
+		yield { code: "email_domain_missing" };
+	});
+	const checker = typeChecker({ email: guard }, "Contact");
+
+	assert.deepEqual(validate({ email: "invalid" }, checker), {
+		ok: false,
+		issue: {
+			path: ["email"],
+			code: "email_missing_at_sign",
+			expected: "an email address containing @",
+		},
+	});
+	assert.deepEqual(validateAll({ email: "invalid" }, checker), {
+		ok: false,
+		issues: [
+			{
+				path: ["email"],
+				code: "email_missing_at_sign",
+				expected: "an email address containing @",
+			},
+			{ path: ["email"], code: "email_domain_missing" },
+		],
+	});
+});
+
+test("failed narrowing without a diagnostic issue uses the generic code", () => {
+	type NonEmptyString = Nominal<string, "NonEmptyString">;
+	const nonEmpty: NarrowingGuard<string, NonEmptyString> = (
+		value,
+	): value is NonEmptyString => value.length > 0;
+	const withoutDiagnosis = narrow(isString, nonEmpty);
+	const withEmptyDiagnosis = narrow(isString, nonEmpty, () => []);
+	const expected = {
+		ok: false,
+		issue: {
+			path: [],
+			code: ValidationIssueCode.NarrowingFailed,
+		},
+	};
+
+	assert.deepEqual(validate("", withoutDiagnosis), expected);
+	assert.deepEqual(validate("", withEmptyDiagnosis), expected);
+});
+
+test("diagnosis does not decide validity", () => {
+	type AnyString = Nominal<string, "AnyString">;
+	let diagnosisCalls = 0;
+	const guard = narrow(
+		isString,
+		(_value): _value is AnyString => true,
+		() => {
+			diagnosisCalls++;
+			return [{ code: "should_not_be_reported" }];
+		},
+	);
+
+	assert.deepEqual(validate("value", guard), { ok: true, value: "value" });
+	assert.equal(diagnosisCalls, 0);
+});
+
+test("narrow accepts TypeCheckers and remains compatible with existing APIs", () => {
+	type ActiveRecord = { active: boolean } & {
+		readonly activeRecord: unique symbol;
+	};
+	const base = typeChecker({ active: isBoolean }, "Record");
+	const guard = narrow(base, (value): value is ActiveRecord => value.active);
+	const checker = typeChecker(guard, "ActiveRecord");
+	const input = Object.freeze({ active: true });
+
+	assert.equal(checker, guard);
+	const result = validate(input, checker);
+	assert.equal(result.ok, true);
+	if (result.ok) {
+		assert.equal(result.value, input);
+	}
+	assert.equal(ensure(input, guard), input);
+	assert.equal(guard({ active: false }), false);
+});
+
+test("nested narrowing executes in order and short-circuits", () => {
+	type Positive = number & { readonly positive: unique symbol };
+	type EvenPositive = Positive & { readonly even: unique symbol };
+	const calls: Array<string> = [];
+	const base = (input: unknown): input is number => {
+		calls.push("base");
+		return typeof input === "number";
+	};
+	const positive = (value: number): value is Positive => {
+		calls.push("positive");
+		return value > 0;
+	};
+	const even = (value: Positive): value is EvenPositive => {
+		calls.push("even");
+		return value % 2 === 0;
+	};
+	const isPositive = narrow(base, positive, () => {
+		calls.push("positive diagnosis");
+		return [{ code: "not_positive" }];
+	});
+	const isEvenPositive = narrow(isPositive, even, () => {
+		calls.push("even diagnosis");
+		return [{ code: "not_even" }];
+	});
+
+	assert.equal(isEvenPositive("2"), false);
+	assert.deepEqual(calls, ["base"]);
+	calls.length = 0;
+	assert.equal(isEvenPositive(-2), false);
+	assert.deepEqual(calls, ["base", "positive"]);
+	calls.length = 0;
+	assert.equal(isEvenPositive(3), false);
+	assert.deepEqual(calls, ["base", "positive", "even"]);
+	calls.length = 0;
+	assert.equal(isEvenPositive(4), true);
+	assert.deepEqual(calls, ["base", "positive", "even"]);
+
+	calls.length = 0;
+	assert.deepEqual(validate(-2, isEvenPositive), {
+		ok: false,
+		issue: { path: [], code: "not_positive" },
+	});
+	assert.deepEqual(calls, ["base", "positive", "positive diagnosis"]);
+	calls.length = 0;
+	assert.deepEqual(validate(3, isEvenPositive), {
+		ok: false,
+		issue: { path: [], code: "not_even" },
+	});
+	assert.deepEqual(calls, ["base", "positive", "even", "even diagnosis"]);
+});

--- a/src/narrow.ts
+++ b/src/narrow.ts
@@ -1,0 +1,56 @@
+import { typeChecker } from "./typeChecker.ts";
+import type { NarrowingGuard, NarrowingIssue, TypeGuard } from "./types.ts";
+import { getDiagnoser, setDiagnoser } from "./validation.private.ts";
+import { ValidationIssueCode } from "./validationIssue.ts";
+
+/**
+ * Composes a type guard with an additional subtype constraint.
+ *
+ * The optional diagnosis is evaluated only by structured validation, after the
+ * base guard succeeds and the narrowing predicate fails.
+ */
+export const narrow = <const T, U extends T>(
+	typeGuard: TypeGuard<T>,
+	narrowing: NarrowingGuard<T, U>,
+	diagnosis?: (value: T) => Iterable<NarrowingIssue>,
+): TypeGuard<U> => {
+	const narrowed = (input: unknown): input is U =>
+		typeGuard(input) && narrowing(input);
+
+	setDiagnoser(narrowed, (input, path, report, context) => {
+		let baseFailed = false;
+		const shouldContinue = getDiagnoser(typeChecker(typeGuard))(
+			input,
+			path,
+			(issue) => {
+				baseFailed = true;
+				return report(issue);
+			},
+			context,
+		);
+		if (baseFailed) {
+			return shouldContinue;
+		}
+
+		const value = input as T;
+		if (narrowing(value)) {
+			return true;
+		}
+
+		let issueReported = false;
+		if (diagnosis) {
+			for (const issue of diagnosis(value)) {
+				issueReported = true;
+				if (!report({ path, ...issue })) {
+					return false;
+				}
+			}
+		}
+		return (
+			issueReported ||
+			report({ path, code: ValidationIssueCode.NarrowingFailed })
+		);
+	});
+
+	return narrowed;
+};

--- a/src/typeChecker.ts
+++ b/src/typeChecker.ts
@@ -10,6 +10,7 @@ import type {
 import {
 	type Diagnoser,
 	getDiagnoser,
+	getRegisteredDiagnoser,
 	setDiagnoser,
 	type ValidationIssueReporter,
 } from "./validation.private.ts";
@@ -427,12 +428,16 @@ export const typeChecker: <const T>(
 		};
 	}
 	if (is$Function(d)) {
+		const registeredDiagnoser = getRegisteredDiagnoser(d);
 		return {
 			typeGuard: d,
 			*serialize() {
 				yield `${d.name || k}`;
 			},
-			diagnose(checker, input, path, report) {
+			diagnose(checker, input, path, report, context) {
+				if (registeredDiagnoser) {
+					return registeredDiagnoser(input, path, report, context);
+				}
 				return (
 					d(input) ||
 					report(

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,17 @@ export type Callable<T = unknown, A extends Array<unknown> = Array<unknown>> = (
  */
 export type TypeGuard<T> = (input: unknown) => input is T;
 
+/** A standard type guard that narrows `T` to a subtype `U`. */
+export type NarrowingGuard<T, U extends T> = (value: T) => value is U;
+
+/** A diagnostic emitted when an additional narrowing constraint fails. */
+export interface NarrowingIssue {
+	/** Machine-readable built-in or caller-defined issue identifier. */
+	readonly code: ValidationIssueCode;
+	/** Description of the expected value, when available. */
+	readonly expected?: string;
+}
+
 /**
  * A type to extract the guarded type from a type guard function.
  * @example
@@ -93,7 +104,7 @@ export type TypeChecker<T> = TypeGuard<T> & {
 export interface ValidationIssue {
 	/** Location of the issue within the input. */
 	readonly path: ReadonlyArray<string | number>;
-	/** Stable machine-readable built-in issue identifier. */
+	/** Stable machine-readable built-in or caller-defined issue identifier. */
 	readonly code: ValidationIssueCode;
 	/** Description of the expected value, when available. */
 	readonly expected?: string;

--- a/src/validation.private.ts
+++ b/src/validation.private.ts
@@ -1,4 +1,4 @@
-import type { TypeChecker, ValidationIssue } from "./types.ts";
+import type { TypeChecker, TypeGuard, ValidationIssue } from "./types.ts";
 
 export interface ValidationContext {
 	readonly objects: WeakSet<WeakKey>;
@@ -15,6 +15,10 @@ export type Diagnoser = (
 
 const diagnosers = new WeakMap<object, Diagnoser>();
 
+export const getRegisteredDiagnoser = (
+	checker: object,
+): Diagnoser | undefined => diagnosers.get(checker);
+
 export const getDiagnoser = <T>(checker: TypeChecker<T>): Diagnoser => {
 	const diagnose = diagnosers.get(checker);
 	if (!diagnose) {
@@ -24,7 +28,7 @@ export const getDiagnoser = <T>(checker: TypeChecker<T>): Diagnoser => {
 };
 
 export const setDiagnoser = <T>(
-	checker: TypeChecker<T>,
+	checker: TypeGuard<T>,
 	diagnose: Diagnoser,
 ): void => {
 	diagnosers.set(checker, diagnose);

--- a/src/validationIssue.ts
+++ b/src/validationIssue.ts
@@ -2,11 +2,13 @@
 export const ValidationIssueCode = {
 	CircularReference: "circular_reference",
 	GuardFailed: "guard_failed",
+	NarrowingFailed: "narrowing_failed",
 	PatternMismatch: "pattern_mismatch",
 	TypeMismatch: "type_mismatch",
 	ValueMismatch: "value_mismatch",
 } as const;
 
-/** A built-in machine-readable validation issue code. */
+/** A built-in or caller-defined machine-readable validation issue code. */
 export type ValidationIssueCode =
-	(typeof ValidationIssueCode)[keyof typeof ValidationIssueCode];
+	| (typeof ValidationIssueCode)[keyof typeof ValidationIssueCode]
+	| (string & Record<never, never>);


### PR DESCRIPTION
## Summary

- add the `narrow()` combinator for reusable subtype predicates
- preserve custom and fallback structured diagnostics without affecting boolean validation
- cover inference, interoperability, short-circuiting, nesting, and input identity

## Tests

- `npm run lint`
- `npm run test`
- `bun test src --coverage --coverage-reporter=lcov`
- `npm run build`
- ESM and CommonJS package-entry smoke tests

Closes #436