### PR TITLE
feat: add fromDiagnosis to derive narrowing guards from diagnoses

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,11 @@ import { typeChecker } from 'https://esm.sh/@nlib/typing@3.0.0';
 import * as assert from "node:assert";
 import {
   type Nominal,
+  type NarrowingIssue,
+  type TypeGuard,
   typeChecker,
   ensure,
+  fromDiagnosis,
   narrow,
   union,
   validate,
@@ -102,6 +105,34 @@ assert.deepEqual(validate("invalid", isContactEmail), {
     expected: "an email address containing @",
   },
 });
+
+// fromDiagnosis makes one generator the source of truth for both the boolean
+// constraint and detailed structured-validation issues.
+type Title = Nominal<string, "Title">;
+function* diagnoseTitle(
+  value: string,
+  returnIssue?: NarrowingIssue,
+): Iterable<NarrowingIssue> {
+  const length = Array.from(value).length;
+  if (length === 0) {
+    yield returnIssue ?? {
+      code: "too_short",
+      expected: "at least 1 code point",
+    };
+  }
+  if (100 < length) {
+    yield returnIssue ?? {
+      code: "too_long",
+      expected: "at most 100 code points",
+    };
+  }
+}
+const isTitle: TypeGuard<Title> = typeChecker(
+  narrow(isString, fromDiagnosis(diagnoseTitle)),
+  "Title",
+);
+assert.equal(isTitle("A title"), true);
+assert.equal(isTitle(""), false);
 
 // Diagnosis paths are relative to the narrowed value. Structural checkers
 // prefix them, and validateAll preserves every issue in iteration order.

--- a/src/fromDiagnosis.test.ts
+++ b/src/fromDiagnosis.test.ts
@@ -1,0 +1,225 @@
+import * as assert from "node:assert";
+import { test } from "node:test";
+import { isString } from "./is/String.ts";
+import { fromDiagnosis, narrow } from "./narrow.ts";
+import { typeChecker } from "./typeChecker.ts";
+import type {
+	NarrowingGuard,
+	NarrowingIssue,
+	Nominal,
+	TypeGuard,
+} from "./types.ts";
+import { validate, validateAll } from "./validate.ts";
+import { ValidationIssueCode } from "./validationIssue.ts";
+
+type Title = Nominal<string, "Title">;
+
+function* diagnoseTitle(
+	value: string,
+	returnIssue?: NarrowingIssue,
+): Iterable<NarrowingIssue> {
+	const length = Array.from(value).length;
+	if (length === 0) {
+		yield returnIssue ?? {
+			code: "too_short",
+			expected: "at least 1 code point",
+		};
+	}
+	if (100 < length) {
+		yield returnIssue ?? {
+			code: "too_long",
+			expected: "at most 100 code points",
+		};
+	}
+}
+
+const contextuallyTyped: NarrowingGuard<string, Title> =
+	fromDiagnosis(diagnoseTitle);
+const explicitlyTyped = fromDiagnosis<string, Title>(diagnoseTitle);
+const withoutOutputContext = fromDiagnosis(diagnoseTitle);
+const _stringGuard: NarrowingGuard<string, string> = withoutOutputContext;
+// @ts-expect-error Output type cannot be inferred from the diagnosis issues.
+const _titleGuardWithoutContext: NarrowingGuard<string, Title> =
+	withoutOutputContext;
+const _titleTypeGuard: TypeGuard<Title> = typeChecker(
+	narrow(isString, fromDiagnosis(diagnoseTitle)),
+	"Title",
+);
+const _incompatibleDirectChecker = typeChecker(
+	// @ts-expect-error A string diagnosis does not produce an unknown-input guard.
+	fromDiagnosis(diagnoseTitle),
+	"IncompatibleTitle",
+);
+void _stringGuard;
+void _titleGuardWithoutContext;
+void _titleTypeGuard;
+void _incompatibleDirectChecker;
+
+test("fromDiagnosis produces a reusable standard narrowing predicate", () => {
+	assert.equal(contextuallyTyped("Title"), true);
+	assert.equal(contextuallyTyped(""), false);
+	assert.equal(explicitlyTyped("Title"), true);
+
+	const value = "Title";
+	if (contextuallyTyped(value)) {
+		const title: Title = value;
+		assert.equal(title, value);
+	}
+	assert.equal("diagnosis" in contextuallyTyped, false);
+	assert.deepEqual(Object.getOwnPropertySymbols(contextuallyTyped), []);
+});
+
+test("the boolean path shares its issue, skips details, and stops at the first issue", () => {
+	let sharedIssue: NarrowingIssue | undefined;
+	let detailedExpressions = 0;
+	const calls: Array<string> = [];
+	const guard: NarrowingGuard<string, Title> = fromDiagnosis(
+		function* (value, returnIssue) {
+			calls.push(`start:${value}`);
+			assert.ok(returnIssue);
+			if (sharedIssue) {
+				assert.equal(returnIssue, sharedIssue);
+			} else {
+				sharedIssue = returnIssue;
+			}
+			if (value.length === 0) {
+				yield returnIssue ?? {
+					code: (() => {
+						detailedExpressions++;
+						return "too_short";
+					})(),
+				};
+				calls.push("after first issue");
+				yield returnIssue;
+			}
+			calls.push("done");
+		},
+	);
+
+	assert.equal(guard(""), false);
+	assert.deepEqual(calls, ["start:"]);
+	assert.equal(detailedExpressions, 0);
+	assert.equal(guard("valid"), true);
+	assert.deepEqual(calls, ["start:", "start:valid", "done"]);
+	assert.equal(detailedExpressions, 0);
+});
+
+test("structured validation calls a derived diagnosis once and returns details", () => {
+	let diagnosisCalls = 0;
+	let detailedExpressions = 0;
+	const derived: NarrowingGuard<string, Title> = fromDiagnosis(
+		function* (value, returnIssue) {
+			diagnosisCalls++;
+			if (value.length === 0) {
+				yield returnIssue ?? {
+					code: (() => {
+						detailedExpressions++;
+						return "too_short";
+					})(),
+					expected: "at least 1 character",
+				};
+				yield returnIssue ?? { code: "title_required" };
+			}
+		},
+	);
+	const guard = narrow(isString, derived);
+
+	assert.deepEqual(validate("", guard), {
+		ok: false,
+		issue: {
+			path: [],
+			code: "too_short",
+			expected: "at least 1 character",
+		},
+	});
+	assert.equal(diagnosisCalls, 1);
+	assert.equal(detailedExpressions, 1);
+
+	diagnosisCalls = 0;
+	detailedExpressions = 0;
+	assert.deepEqual(validateAll("", guard), {
+		ok: false,
+		issues: [
+			{
+				path: [],
+				code: "too_short",
+				expected: "at least 1 character",
+			},
+			{ path: [], code: "title_required" },
+		],
+	});
+	assert.equal(diagnosisCalls, 1);
+	assert.equal(detailedExpressions, 1);
+});
+
+test("structured validation preserves base failures and successful identity", () => {
+	let diagnosisCalls = 0;
+	const base = typeChecker(
+		(input: unknown): input is string => typeof input === "string",
+		"TrackedString",
+	);
+	const derived: NarrowingGuard<string, Title> = fromDiagnosis((value) => {
+		diagnosisCalls++;
+		return diagnoseTitle(value);
+	});
+	const guard = narrow(base, derived);
+
+	assert.deepEqual(validate(1, guard), {
+		ok: false,
+		issue: {
+			path: [],
+			code: ValidationIssueCode.GuardFailed,
+			expected: base.toString(),
+			actualType: "Number",
+		},
+	});
+	assert.equal(diagnosisCalls, 0);
+
+	const input = "Title";
+	const result = validate(input, guard);
+	assert.deepEqual(result, { ok: true, value: input });
+	assert.equal(diagnosisCalls, 1);
+});
+
+test("an unknown-input diagnosis is directly compatible with typeChecker", () => {
+	function* diagnoseUnknownTitle(
+		value: unknown,
+		returnIssue?: NarrowingIssue,
+	): Iterable<NarrowingIssue> {
+		if (typeof value !== "string") {
+			yield returnIssue ?? { code: "not_a_string" };
+			return;
+		}
+		yield* diagnoseTitle(value, returnIssue);
+	}
+	const guard: NarrowingGuard<unknown, Title> =
+		fromDiagnosis(diagnoseUnknownTitle);
+	const checker = typeChecker(guard, "Title");
+
+	assert.equal(checker, guard);
+	assert.equal(checker("Title"), true);
+	assert.equal(checker(""), false);
+	assert.equal(checker(1), false);
+});
+
+test("errors after the first diagnosis remain lazy on the boolean path", () => {
+	const error = new Error("diagnosis failed");
+	const guard: NarrowingGuard<string, Title> = fromDiagnosis(
+		function* (_value, returnIssue) {
+			yield returnIssue ?? { code: "first_issue" };
+			throw error;
+		},
+	);
+
+	assert.equal(guard("invalid"), false);
+	assert.throws(
+		() =>
+			fromDiagnosis<string, Title>(function* (_value, returnIssue) {
+				if (!returnIssue) {
+					yield { code: "details_only" };
+				}
+				throw error;
+			})("invalid"),
+		error,
+	);
+});

--- a/src/narrow.ts
+++ b/src/narrow.ts
@@ -3,6 +3,35 @@ import type { NarrowingGuard, NarrowingIssue, TypeGuard } from "./types.ts";
 import { getDiagnoser, setDiagnoser } from "./validation.private.ts";
 import { ValidationIssueCode } from "./validationIssue.ts";
 
+type Diagnosis<T> = (
+	value: T,
+	returnIssue?: NarrowingIssue,
+) => Iterable<NarrowingIssue>;
+
+const returnIssue: NarrowingIssue = {
+	code: ValidationIssueCode.NarrowingFailed,
+};
+const diagnoses = new WeakMap<object, unknown>();
+
+/**
+ * Derives a narrowing predicate from a diagnosis generator.
+ *
+ * Boolean evaluation stops at the first issue and supplies a shared issue so
+ * callers can skip constructing detailed diagnostics with `returnIssue ??`.
+ */
+export const fromDiagnosis: <T, U extends T>(
+	diagnosis: Diagnosis<T>,
+) => NarrowingGuard<T, U> = <T, U extends T>(diagnosis: Diagnosis<T>) => {
+	const guard: NarrowingGuard<T, U> = (value): value is U => {
+		for (const _issue of diagnosis(value, returnIssue)) {
+			return false;
+		}
+		return true;
+	};
+	diagnoses.set(guard, diagnosis);
+	return guard;
+};
+
 /**
  * Composes a type guard with an additional subtype constraint.
  *
@@ -12,11 +41,9 @@ import { ValidationIssueCode } from "./validationIssue.ts";
 export const narrow = <const T, U extends T>(
 	typeGuard: TypeGuard<T>,
 	narrowing: NarrowingGuard<T, U>,
-	diagnosis?: (
-		value: T,
-		returnIssue?: NarrowingIssue,
-	) => Iterable<NarrowingIssue>,
+	diagnosis?: Diagnosis<T>,
 ): TypeGuard<U> => {
+	const derivedDiagnosis = diagnoses.get(narrowing) as Diagnosis<T> | undefined;
 	const narrowed = (input: unknown): input is U =>
 		typeGuard(input) && narrowing(input);
 
@@ -36,13 +63,14 @@ export const narrow = <const T, U extends T>(
 		}
 
 		const value = input as T;
-		if (narrowing(value)) {
+		if (!derivedDiagnosis && narrowing(value)) {
 			return true;
 		}
 
 		let issueReported = false;
-		if (diagnosis) {
-			for (const issue of diagnosis(value)) {
+		const diagnose = derivedDiagnosis ?? diagnosis;
+		if (diagnose) {
+			for (const issue of diagnose(value)) {
 				issueReported = true;
 				if (!report({ ...issue, path: path.concat(issue.path ?? []) })) {
 					return false;
@@ -50,6 +78,7 @@ export const narrow = <const T, U extends T>(
 			}
 		}
 		return (
+			derivedDiagnosis !== undefined ||
 			issueReported ||
 			report({ path, code: ValidationIssueCode.NarrowingFailed })
 		);


### PR DESCRIPTION
## Summary
- add fromDiagnosis to derive narrowing predicates from diagnosis generators
- preserve private diagnosis metadata and one-pass structured validation
- document and test boolean short-circuiting, detailed issues, and type inference

## Tests
- npm run lint
- npm run test:type
- npm run test:unit
- npm run test:example
- npx c8 npm run test
- bun test src --coverage --coverage-reporter=lcov
- npm run build
- ESM and CommonJS package-entry smoke tests

Closes #439